### PR TITLE
Bugfix for Date Fields. Enhancement to set HostId in ServiceConnection

### DIFF
--- a/src/com/docuware/dev/Extensions/ServiceConnection.java
+++ b/src/com/docuware/dev/Extensions/ServiceConnection.java
@@ -67,6 +67,7 @@ public class ServiceConnection {
 
     private final ServiceDescription serviceDescription;
     private static PlatformClient client;
+    private static String hostId;
 
     /**
      * @deprecated 
@@ -124,6 +125,10 @@ public class ServiceConnection {
         return CompletableFuture.runAsync(() -> {
             MethodInvocation.getAsync(serviceDescription, serviceDescription.getLinks(), "logout", null);
         });
+    }
+
+    public static void SetHostId(String HostId){
+        hostId = HostId;
     }
 
     /**
@@ -396,6 +401,10 @@ public class ServiceConnection {
     }
 
     private static ServiceConnection create(MultivaluedMap<String, String> formData, String baseuri, String rel, ServiceConnectionTransportData sclbd) {
+        if(hostId != null){
+            formData.add("HostId", hostId);
+        }
+        
         client = new PlatformClient(baseuri, sclbd);
         LinkResolver resolver = client.getLinkResolver();
         ServiceDescription serviceDescription = client.getServiceDescription();

--- a/src/com/docuware/dev/schema/_public/services/platform/DocumentIndexFieldValueBase.java
+++ b/src/com/docuware/dev/schema/_public/services/platform/DocumentIndexFieldValueBase.java
@@ -38,6 +38,7 @@ private ItemChoiceType itemElementName;//test
         @XmlElement(name = "Decimal", type = BigDecimal.class),
         @XmlElement(name = "String", type = String.class),
         @XmlElement(name = "Keywords", type = DocumentIndexFieldKeywords.class),
+        @XmlElement(name = "Date", type = GregorianCalendar.class),
         @XmlElement(name = "DateTime", type = GregorianCalendar.class)
     })
     protected Object item;


### PR DESCRIPTION
Added missing xelement definition for "Date"-fields.
Also now you can set before ServiceConnection-Creation the hostId so the application has it's identifier. This is already for .Net API in place.